### PR TITLE
feature: Add oracle db to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,25 @@
-version: "3"
-
 services:
   mailcatcher:
-    image: dockage/mailcatcher:0.8.0
+    image: dockage/mailcatcher:0.9.0
     ports:
       - "1080:1080"
       - "1025:1025"
+  oracle-db:
+    image: container-registry.oracle.com/database/enterprise:latest
+    environment:
+      - ORACLE_SID=ORCLCDB
+      - ORACLE_PDB=ORCLPDB1
+      - ORACLE_PWD=Oracle_123
+    ports:
+      - "1521:1521"
+    volumes:
+      - oracle-data:/opt/oracle/oradata
+      - oracle-backup:/opt/oracle/backup
+    healthcheck:
+      test: [ "CMD", "sqlplus", "-L", "sys/Oracle_123@//localhost:1521/ORCLCDB as sysdba", "@healthcheck.sql" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  oracle-data:
+  oracle-backup:


### PR DESCRIPTION
Set up first version of oracle db on docker compose. For further development

Refs: CU-8694kp6jn