### PR TITLE
fix: Repair chunks load for @tabler/icons-react

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,12 @@ export default defineConfig(({mode}) => {
         },
       },
     },
+    resolve: {
+      alias: {
+        // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
+        '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs',
+      }
+    }
     // base: '/MeowHub/',
   }
 })


### PR DESCRIPTION
Add alias as a workaround recommended by creators of the library.

Refs: CU-86973a6tu